### PR TITLE
fix:在windows10专业版本下面antd4.20.5版本报错以及更新最近antd5.6.1版本后的错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.7.0",
     "@xstate/react": "^3.0.0",
-    "antd": "^4.20.5",
+    "antd": "^5.6.1",
     "axios": "^0.27.2",
     "cross-spawn": "^7.0.3",
     "electron-is-dev": "^2.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 
-import 'antd/dist/antd.css';
+import 'antd/dist/antd.js.map';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
错误1：在windows10专业版本下面antd4.20.5版本报错：Failed to parse source map: 'webpack://antd/./components/config-provider/style/index.less' URL is not supported 错误2：使用npm更新最新版本antd5.6.1后，报错ERROR in ./src/index.js 7:0-28 Module not found: Error: Can't resolve 'antd/dist/antd.css'